### PR TITLE
Update Productivity Bundle

### DIFF
--- a/bundles/productivity
+++ b/bundles/productivity
@@ -21,5 +21,5 @@ cask "mysqlworkbench"
 cask "slack"
 
 # Text Editors
-cask "sublime"
+cask "sublime-text"
 EOF


### PR DESCRIPTION
The cask command to download sublime is pointing to something entirely different. With this change the script will correctly install the text editor.